### PR TITLE
Follow Cargo Book recommendations to link native library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,5 @@ authors = ["nyantec GmbH <dev@nyantec.com>"]
 license = "MirOS"
 description = "Rust bindings to libsensors"
 
-[dependencies]
-
-[build]
-rustc-link-lib = ["sensors"]
+links = "sensors"
+build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-lib=dylib=sensors");
+}


### PR DESCRIPTION
This PR use the `links` key in the manifest and a build script to link with the libsensors library, as recommended by the [Cargo Book](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key).
The `rustc-link-lib` key is intended to override existing key generated by build scripts. 